### PR TITLE
Changes in valve to avoid issues in liferay login process

### DIFF
--- a/open-infinity-security-vault/open-infinity-security-vault-common/src/main/java/org/openinfinity/sso/security/util/GlobalVariables.java
+++ b/open-infinity-security-vault/open-infinity-security-vault-common/src/main/java/org/openinfinity/sso/security/util/GlobalVariables.java
@@ -47,7 +47,13 @@ public interface GlobalVariables {
 	/**
 	 * Represents the attribute based user's session attributes key fetched from the properties file.
 	 */
-	public static final String ATTRIBUTE_BASED_USER_ATTRIBUTES = "sso.attribute.session.attributes"; 
+	public static final String ATTRIBUTE_BASED_USER_ATTRIBUTES = "sso.attribute.session.attributes";
+
+    /**
+     * Represents the configuration key for attribute based valve. Valve will set principal in request
+     * (default behavior). In case setting principal is not wanted, this should be set as false.
+     */
+    public static final String ATTRIBUTE_BASED_SHOULD_SET_PRINCIPAL = "sso.attribute.should.set.principal";
 
 	/**
 	 * Represents the configuration key for header based session from the properties file.
@@ -103,5 +109,5 @@ public interface GlobalVariables {
 	 * Security vault properties location identifier.
 	 */
 	public static final String SECURITY_VAULT_PROPERTIES_FILE_LOCATION = "security.vault.properties.file";
-	
+
 }


### PR DESCRIPTION
Added configuration that can be used to prevent valve from writing principal into request. 

If principal is in the request Liferay will think that user has logged in and have session in liferay. Authentication process will be skipped in liferay because user is in the request. Important change in this pr is the if sentence in the AttributeBasedValve line 88.

Changed logging levels a bit.
